### PR TITLE
Adding support for x86_64

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -15,6 +15,9 @@ case "$(uname -s)|$(uname -m)" in
 	"Linux|amd64")
 		DOWNLOAD_URL="https://github.com/GoogleCloudPlatform/terraformer/releases/download/${ASDF_INSTALL_VERSION}/terraformer-all-linux-amd64"
 		;;
+	"Linux|x86_64")
+		DOWNLOAD_URL="https://github.com/GoogleCloudPlatform/terraformer/releases/download/${ASDF_INSTALL_VERSION}/terraformer-all-linux-amd64"
+		;;
 	"Linux|arm64")
 		DOWNLOAD_URL="https://github.com/GoogleCloudPlatform/terraformer/releases/download/${ASDF_INSTALL_VERSION}/terraformer-all-linux-arm64"
 		;;


### PR DESCRIPTION
Typically 64-bit AMD/Intel platforms on Linux will return `x86_64` as their architecture. This is binary compatible with the `amd64` releases of terraformer.