### PR TITLE
Add post-install message to advise users of next steps

### DIFF
--- a/bin/post-plugin-update
+++ b/bin/post-plugin-update
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e
+
+# advise user of the next steps to ensure they can use the terraformer tool
+echo "Please ensure you also set up the Terraform plugin directory"
+echo "See the instructions here, from Step 4 onwards"
+echo "https://github.com/GoogleCloudPlatform/terraformer#installation"


### PR DESCRIPTION
It took me a few mins to understand why my new terraformer install wasn't working, and there's a long thread about it here https://github.com/GoogleCloudPlatform/terraformer/issues/439

This change adds a short message after installation to guide the user to the next steps to complete the install.